### PR TITLE
Add performance metrics to acquisition

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -34,9 +34,9 @@ class Controller:
         Initialise controller for GUI and digitiser
         '''
 
-        # Initialise logging
+        # Initialise logging and tracking
         setup_logging()
-
+        self.tracker = Tracker()
 
         # digitiser connection first
         self.dig_config = dig_config
@@ -89,6 +89,8 @@ class Controller:
         # visualise (and at some point, collect in a file)
         wf_size, ADCs = self.acquisition_worker.data
         self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs)
+        # ping the tracker (make this optional)
+        self.tracker.track()
         # prep the next thread
         if self.digitiser.isAcquiring:
             self.worker_wait_condition.notify_one()

--- a/core/controller.py
+++ b/core/controller.py
@@ -264,9 +264,9 @@ class Tracker:
         self.bytes_ps += nbytes
 
         t_check = time.perf_counter()
-        if t_check - self.last_report >= 1.0:
+        if t_check - self.last_time >= 1.0:
             MB = self.bytes_ps / 1000000
-            print(f'|| {self.events_ps} events/sec || {MB:.2f} MB/sec ||')
-            self.last_report = t_check
+            logging.info(f'|| {self.events_ps} events/sec || {MB:.2f} MB/sec ||')
+            self.last_time = t_check
             self.bytes_ps = 0
             self.events_ps = 0

--- a/core/controller.py
+++ b/core/controller.py
@@ -90,7 +90,7 @@ class Controller:
         wf_size, ADCs = self.acquisition_worker.data
         self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs)
         # ping the tracker (make this optional)
-        self.tracker.track()
+        self.tracker.track(ADCs.nbytes)
         # prep the next thread
         if self.digitiser.isAcquiring:
             self.worker_wait_condition.notify_one()

--- a/core/controller.py
+++ b/core/controller.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+import time
 #from caen_felib import lib, device, error
 from typing import Optional
 
@@ -238,3 +239,32 @@ class AcquisitionWorker(QObject):
     def stop(self):
         self.digitiser.stop_acquisition()
         self.wait_condition.wakeAll()
+
+
+class Tracker:
+    '''
+    Tracking class that keeps track of:
+        - number of collected events
+        - speed at which data is being collected
+    '''
+
+    def __init__(self):
+        self.start_time = time.perf_counter()
+        self.bytes_ps   = 0
+        self.events_ps  = 0
+        self.last_time  = self.start_time
+
+    def track(self, nbytes: int = 0):
+        '''
+        Tracker outputting the number of events that arrive per second
+        '''
+        self.events_ps += 1
+        self.bytes_ps += nbytes
+
+        t_check = time.perf_counter()
+        if t_check - self.last_report >= 1.0:
+            MB = self.bytes_ps / 1000000
+            print(f'|| {self.events_ps} events/sec || {MB:.2f} MB/sec ||')
+            self.last_report = t_check
+            self.bytes_ps = 0
+            self.events_ps = 0

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -234,7 +234,7 @@ class Digitiser():
         try:
             self.endpoint.read_data(100, self.data) # timeout first number in ms
             return (self.data[7].value, self.data[3].value)
-        except error.ERROR as ex:
+        except error.Error as ex:
             logging.exception("Error in readout:")
             if ex.code is error.ErrorCode.TIMEOUT:
                 logging.error("TIMEOUT")


### PR DESCRIPTION
This PR addresses #7 by adding very basic acquisition metrics for the digitiser as can be seen in the below linked images:
<img width="1609" height="757" alt="image" src="https://github.com/user-attachments/assets/b6abf0b1-b451-4f6c-b91e-9e41cfc47d07" />
<img width="1609" height="757" alt="image" src="https://github.com/user-attachments/assets/393418a5-8c0e-4c0d-aa5a-4021e4c5ece5" />

Currently, there is strange behaviour when working with the software trigger that needs to be debugged. If you alter the frequency of the input signal the event rate increases. I believe implementing #3 should resolve this as the software trigger is currently unthrottled (ie: I just let it work as fast as the slowest part allows it to).