### PR TITLE
Multi channel h5 writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# CAEN stuff
+CAENBoard_GENERICLog.txt  
+CAENParametersLog.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CAENBoard_GENERICLog.txt
+++ b/CAENBoard_GENERICLog.txt
@@ -1,0 +1,2 @@
+[       0.011][EE][CAENBoard_GENERIC.c::2526]: Open digitizer failed due to a comm error: -1
+[       0.011][EE][CAENDPPLayer.c::118]: From c_newDigitizer: Error Calling CAENDigitizer API

--- a/CAENBoard_GENERICLog.txt
+++ b/CAENBoard_GENERICLog.txt
@@ -1,2 +1,2 @@
-[       0.011][EE][CAENBoard_GENERIC.c::2526]: Open digitizer failed due to a comm error: -1
-[       0.011][EE][CAENDPPLayer.c::118]: From c_newDigitizer: Error Calling CAENDigitizer API
+[       0.009][EE][CAENBoard_GENERIC.c::2526]: Open digitizer failed due to a comm error: -1
+[       0.009][EE][CAENDPPLayer.c::118]: From c_newDigitizer: Error Calling CAENDigitizer API

--- a/configs/debug.conf
+++ b/configs/debug.conf
@@ -7,3 +7,9 @@ link_num         = 0
 conet_node       = 0
 vme_base_address = 0
 dig_authority    = 'caen.internal'
+
+[output_settings]
+
+file_name = 'output_file'   # this will always be appended with a timestamp and .h5
+overwrite = True            # overwrite the file if you want
+

--- a/configs/recording/five_ns_window.conf
+++ b/configs/recording/five_ns_window.conf
@@ -4,6 +4,7 @@ record_length  = 4096  # ns
 pre_trigger    = 512   # ns
 trigger_mode   = 'SELFTRIG' # look into the differing methods, trigger on channel based on threshold is an option
                           # SWTRIG, SELFTRIG, (not yet implemented) <EXTTRIG>
+software_timeout = 0      # hard software timeout between each digitiser poll (s)
 
 [channel_settings]
 
@@ -16,8 +17,39 @@ ch1 =   {'enabled'     : False,
          'self_trigger': False,
          'threshold'   : 0,
          'polarity'    : 'positive'}
+         
+ch2 =   {'enabled'     : True,
+         'self_trigger': True,
+         'threshold'   : 600,
+         'polarity'    : 'positive'}
+
+ch3 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch4 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch5 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch6 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch7 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
 
 [output_settings]
 
-file_name = 'output_file'   # this will always be appended with a timestamp and .h5
-overwrite = True            # overwrite the file if you want
+file_name = 'data/output_file'    # this will always be appended with a timestamp and .h5
+overwrite = True                  # overwrite the file if you want
+h5_flush_size = 20                # number of values added to h5 files per write

--- a/configs/recording/five_ns_window.conf
+++ b/configs/recording/five_ns_window.conf
@@ -17,4 +17,7 @@ ch1 =   {'enabled'     : False,
          'threshold'   : 0,
          'polarity'    : 'positive'}
 
+[output_settings]
 
+file_name = 'output_file'   # this will always be appended with a timestamp and .h5
+overwrite = True            # overwrite the file if you want

--- a/core/controller.py
+++ b/core/controller.py
@@ -50,6 +50,9 @@ class Controller:
         self.dig_config = dig_config
         self.rec_config = rec_config
 
+        # initialise a universal event counter for sanity purposes
+        self.event_counter = 0
+
         # Thread-safe communication channels
         self.cmd_buffer = Queue(maxsize=10)
         self.display_buffer = Queue(maxsize=1024)
@@ -114,7 +117,9 @@ class Controller:
                 break
 
             try:
+                # you must pass wf_size and ADCs through. 
                 wf_size, ADCs = data
+                self.event_counter += 1
 
                 # update visuals
                 self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs)

--- a/core/controller.py
+++ b/core/controller.py
@@ -118,7 +118,6 @@ class Controller:
                     mapping[ch] = i
                     i += 1
 
-        #print(f'mapping: {mapping}')
         return mapping
 
     def data_handling(self):
@@ -135,7 +134,6 @@ class Controller:
             try:
                 # you must pass wf_size and ADCs through. 
                 wf_size, ADCs, ch = data
-                #print(f'ch: {ch}')
 
                 # update visuals
                 self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs)
@@ -146,7 +144,6 @@ class Controller:
                 # push data to writer buffer 
                 if self.recording:
                     write_data = wf_size, ADCs, self.event_counter
-                    #self.writer_buffer.put(write_data)
 
                     # multi channel writing
                     ch = int(ch)

--- a/core/controller.py
+++ b/core/controller.py
@@ -135,7 +135,6 @@ class Controller:
             try:
                 # you must pass wf_size and ADCs through. 
                 wf_size, ADCs, ch = data
-                self.event_counter += 1
 
                 # update visuals
                 self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs)
@@ -144,12 +143,15 @@ class Controller:
                 self.tracker.track(ADCs.nbytes)
 
                 # push data to writer buffer 
-                self.write_buffer.put(data)
+                write_data = wf_size, ADCs, self.event_counter
+                self.write_buffer.put(write_data)
 
                 '''
                 # multi channel writing
                 self.write_buffers[self.ch_mapping[ch]].put(data)
                 '''
+                
+                self.event_counter += 1
 
             except Exception as e:
                 logging.exception(f"Error updating display: {e}")

--- a/core/df_classes.py
+++ b/core/df_classes.py
@@ -20,12 +20,12 @@ def return_rwf_class(WD_version : str, shape : int) -> Type[tb.IsDescription]:
             evt_no    = tb.UInt32Col()
             channel   = tb.UInt32Col()
             timestamp = tb.UInt64Col()
-            rwf       = tb.UInt16Col(shape=(samples,))
+            rwf       = tb.UInt16Col(shape=(shape,))
     elif WD_version == 2:
         class rwf_df(tb.IsDescription):
             evt_no    = tb.UInt32Col()
             channel   = tb.UInt32Col()
             timestamp = tb.UInt64Col()
-            rwf       = tb.Float32Col(shape = (samples,))
+            rwf       = tb.Float32Col(shape = (shape,))
 
     return rwf_df

--- a/core/df_classes.py
+++ b/core/df_classes.py
@@ -1,0 +1,31 @@
+import tables as tb
+from typing import Type
+
+
+class config_class(tb.IsDescription):
+     '''
+     Holds dictionary (key, value) pairs
+     '''
+     key   = tb.StringCol(90) # 90 character string maximum, you've been warned!
+     value = tb.StringCol(90)
+
+
+
+def return_rwf_class(WD_version : str, shape : int) -> Type[tb.IsDescription]:
+    '''
+    Based on MULE shapes, expect output to be formatted as such, for forwards compatibility.
+    '''
+    if WD_version == 1:
+        class rwf_df(tb.IsDescription):
+            evt_no    = tb.UInt32Col()
+            channel   = tb.UInt32Col()
+            timestamp = tb.UInt64Col()
+            rwf       = tb.UInt16Col(shape=(samples,))
+    elif WD_version == 2:
+        class rwf_df(tb.IsDescription):
+            evt_no    = tb.UInt32Col()
+            channel   = tb.UInt32Col()
+            timestamp = tb.UInt64Col()
+            rwf       = tb.Float32Col(shape = (samples,))
+
+    return rwf_df

--- a/core/io.py
+++ b/core/io.py
@@ -63,7 +63,7 @@ def create_config_table(h5file : tb.File, dictionary : dict, name : str, descrip
             if type(values) is dict:
                 # single nest only! any more and you've made the config too complicated
                 for key_2, value_2 in values.items():
-                    print(key_2)
+                    #print(key_2)
                     config_details['key'] = f'{key}/{key_2}'
                     config_details['value'] = value_2
                     config_details.append()

--- a/core/io.py
+++ b/core/io.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import tables as tb
+import core.df_classes as df_class 
 
 import ast
 import configparser
@@ -43,3 +45,30 @@ def read_config_file(file_path  :  str) -> dict:
             arg_dict[key] = ast.literal_eval(config[section][key])
 
     return arg_dict
+
+
+def create_config_table(h5file : tb.File, dictionary : dict, name : str, description = "config"):
+        
+        # create config node if it doesnt exist already
+        try:
+                group = h5file.get_node("/", "config")
+        except tb.NoSuchNodeError:
+                group = h5file.create_group("/", "config", "Config parameters")
+        
+        # create table
+        table = h5file.create_table(group, name, df_class.config_class, description)
+        # assign the rows by component
+        config_details = table.row
+        for key, values in dictionary.items():
+            if type(values) is dict:
+                # single nest only! any more and you've made the config too complicated
+                for key_2, value_2 in values.items():
+                    print(key_2)
+                    config_details['key'] = f'{key}/{key_2}'
+                    config_details['value'] = value_2
+                    config_details.append()
+            else:
+                config_details['key']   = key
+                config_details['value'] = values
+                config_details.append()
+        table.flush()

--- a/core/worker.py
+++ b/core/worker.py
@@ -14,7 +14,7 @@ class AcquisitionWorker(Thread):
     All commands and data flow through thread-safe mechanisms (queue, locks, events).
     '''
 
-    def __init__(self, cmd_buffer: Queue, display_buffer: Queue, stop_event: Event):
+    def __init__(self, cmd_buffer: Queue, display_buffer: Queue, stop_event: Event, sw_timeout: float):
         super().__init__(daemon=True)
         self.digitiser = None
         self.stop_event = stop_event
@@ -24,6 +24,7 @@ class AcquisitionWorker(Thread):
         self.data_ready_callback = None  # set by Controller
         self.dig_config = None
         self.rec_config = None
+        self.sw_timeout = sw_timeout     # set in config file (s)
 
     def enqueue_cmd(self, cmd_type: CommandType, *args):
         '''
@@ -142,7 +143,7 @@ class AcquisitionWorker(Thread):
                         logging.exception(f"Acquisition error: {e}")
 
                 # to avoid busy digitiser - add software timeout as member variable
-                time.sleep(1)
+                time.sleep(self.sw_timeout)
 
         except Exception as e:
             logging.exception(f"Fatal error in AcquisitionWorker: {e}")

--- a/core/writer.py
+++ b/core/writer.py
@@ -67,7 +67,7 @@ class Writer(Thread):
         ***This needs to be implemented.***
         '''
 
-        for wf_size, evt, rwf in self.local_buffer:
+        for wf_size, rwf, evt in self.local_buffer:
 
             # if we know the size of the waveforms already, don't create the class again.
             if self.wf_size is None:
@@ -76,7 +76,7 @@ class Writer(Thread):
                 self.rwf_table = self.h5file.create_table(self.rwf_group, 'rwf', self.rwf_class, "raw waveforms")
                 self.rows      =  self.rwf_table.row
 
-            self.rows['evt_no'] = idk_bro_where_should_this_be_set?? 
+            self.rows['evt_no'] = evt 
             self.rows['rwf']    = rwf 
             self.rows.append()
 

--- a/core/writer.py
+++ b/core/writer.py
@@ -7,14 +7,6 @@ import core.df_classes as df_class
 import core.io as io
 
 
-'''
-Currently if stop event is set then run() exits and the data left in the shared buffer is discarded.
-So, if we want to safely stop the entire program without discarding any data already in the shared buffer,
-there will have to be some logic inside AcquisitionWorker that lets the writer threads flush and write all
-the remaining data inside the shared buffers before terminating the threads.
-'''
-
-
 class Writer(Thread):
     '''
     Writes channel data to h5 file.

--- a/core/writer.py
+++ b/core/writer.py
@@ -1,0 +1,69 @@
+from queue import Queue, Empty
+from threading import Thread, Event, Lock
+import logging
+
+
+'''
+Currently if stop event is set then run() exits and the data left in the shared buffer is discarded.
+So, if we want to safely stop the entire program without discarding any data already in the shared buffer,
+there will have to be some logic inside AcquisitionWorker that lets the writer threads flush and write all
+the remaining data inside the shared buffers before terminating the threads.
+'''
+
+
+class Writer(Thread):
+    '''
+    Writes channel data to h5 file.
+    '''
+    def __init__(self, ch: int, flush_size: int, write_buffer: Queue, stop_event: Event):
+        super().__init__(daemon=True)
+        self.ch = ch
+        self.flush_size = flush_size
+        self.write_buffer = write_buffer
+        self.stop_event = stop_event
+        self.filename = f"some_name_ch_{self.ch}"
+        self.local_buffer = []
+
+    def write_h5(self):
+        '''
+        Write local buffer to h5 file and then clear local buffer.
+
+        ***This needs to be implemented.***
+        '''
+        pass
+
+    def run(self):
+        '''
+        Writer hot loop.
+        '''
+        logging.info(f"Writer thread started (ch {self.ch}).")
+        try:
+            while not self.stop_event.is_set():
+                # First load data from shared buffer into local buffer
+                for _ in range(self.flush_size):
+                    try:
+                        self.local_buffer.append(self.write_buffer.get_nowait())
+                    except Empty:   # exit for loop if shared buffer is empty
+                        break
+
+                # If no data was added to local buffer, don't write to h5 file
+                if len(self.local_buffer) == 0:
+                    continue
+
+                # Write all data in local buffer to h5 file
+                self.write_h5()
+
+        except Exception as e:
+            logging.exception(f"Fatal error in Writer (ch {self.ch}): {e}")
+
+        # When stop_event() is set, call cleanup()
+        self.cleanup()
+        logging.info(f"Writer thread exited cleanly (ch {self.ch}).")
+
+    def cleanup(self):
+        '''
+        Handles cleanup of writer thread and h5 file.
+
+        ***This needs to be implemented.***
+        '''
+        pass

--- a/core/writer.py
+++ b/core/writer.py
@@ -62,24 +62,12 @@ class Writer(Thread):
         Write local buffer to h5 file and then clear local buffer.
 
         assumption is that the local buffer contains tuples of:
-        (waveform_size, ADCs)
+        (waveform_size, ADCs, event_no)
         where ADCs is the actual raw waveform array
-
-        we need the waveform_size once
-
-        ***This needs to be implemented.***
         '''
 
         for wf_size, rwf, evt in self.local_buffer:
-            '''
-            print(f'{evt}')
-            print(rwf)
-            print('='*20)
-            print('='*20)
-            print('='*20)
-            '''
-
-            # if we know the size of the waveforms already, don't create the class again.
+        # if we know the size of the waveforms already, don't create the class again.
             if self.wf_size is None:
                 self.wf_size = wf_size 
                 self.rwf_class = df_class.return_rwf_class(self.dig_config['dig_gen'], self.wf_size)
@@ -128,8 +116,6 @@ class Writer(Thread):
     def cleanup(self):
         '''
         Handles cleanup of writer thread and h5 file.
-
-        ***This needs to be implemented.***
         '''
         # close the h5 file
         self.h5file.close()

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -232,6 +232,9 @@ class Digitiser():
             logging.exception("Stopping acsquisition failed:")
 
     def acquire(self):
+        '''
+        Must return data with format (wf_size, ADCs, ch)
+        '''
         match self.trigger_mode:
             case 'SWTRIG':
                 return self.SW_record()
@@ -252,7 +255,10 @@ class Digitiser():
         try:
             self.endpoint.has_data(check_timeout)
             self.endpoint.read_data(read_timeout, self.data) # timeout first number in ms
-            return (self.data[7].value, self.data[3].value)
+            wf_size = self.data[7].value
+            ADCs = self.data[3].value
+            ch = self.data[0].value
+            return (wf_size, ADCs, ch)
         except error.Error as ex:
             #logging.exception("Error in readout:")
             if ex.code is error.ErrorCode.TIMEOUT:
@@ -279,7 +285,10 @@ class Digitiser():
         try:
             self.endpoint.has_data(check_timeout)
             self.endpoint.read_data(read_timeout, self.data)
-            return (self.data[7].value, self.data[3].value)
+            wf_size = self.data[7].value
+            ADCs = self.data[3].value
+            ch = self.data[0].value
+            return (wf_size, ADCs, ch)
         except error.Error as ex:
             #logging.exception("Error in readout:")
             if ex.code is error.ErrorCode.TIMEOUT:

--- a/ui/elements.py
+++ b/ui/elements.py
@@ -177,3 +177,18 @@ class Acquisition(QGroupBox):
         if digitiser exists, must force digitiser.isAcquiring
         then enables digitiser.isRecording also
         '''
+        if self.recording:
+            logging.info('Stopping recording...')
+            self.record.setStyleSheet("background-color: green; color: black")
+            self.recording = False
+            # stop the recording
+            self.controller.stop_recording()
+        else:
+            if self.acquiring:
+                logging.info('Starting recording...')
+                self.record.setStyleSheet("background-color: red; color: white")
+                self.recording = True
+                # start the recording
+                self.controller.start_recording()
+            else:
+                logging.info('Attempted to record but failed since not acquiring...')

--- a/ui/elements.py
+++ b/ui/elements.py
@@ -147,7 +147,7 @@ class Acquisition(QGroupBox):
         else:
             self.start_stop.setStyleSheet("background-color: green; color: black")
             self.start_stop.clicked.connect(self.toggle_acquisition)
-            self.record.setStyleSheet("background-color: red; color: black")
+            self.record.setStyleSheet("background-color: green; color: black")
             self.record.clicked.connect(self.toggle_recording)
        
 


### PR DESCRIPTION
This PR implements writing raw data to h5 files. 

A new Writer class has been added which inherits from threading.Thread. This class runs on its own thread by overriding Thread.run() and continuously reads data from a shared thread safe buffer (queue.Queue). 

The acquisition worker class, which also runs on its own thread, continuously polls the digitiser and pushes acquired data to a thread safe buffer shared between the acquisition worker class and the controller class (running on the main thread). The controller class then pushes the data to the writer buffer. The writer class and writer buffer are member variables of the controller class.

To extend this to multi channel writing, controller now has a list of write buffers and a list of writer threads, one for each channel. This also means that each channel of data writes to its own h5 file. A new member function called get_ch_mapping() has been added to controller which returns a dictionary that maps channel number to the index of the lists that contain the writer threads/buffers. Now, when acquisition worker provides data, the appropriate writer buffer can be written to.

As previously said, each channel writes to its own h5 file. Each h5 file also contains the config files provided at the start of the program.

A new section called output settings has been added to the recording config file. This section introduces three new config parameters: file_name, overwrite, and h5_flush_size. file_name is simply the file path of the h5 files. overwrite is a boolean which overwrites the file path provided if set to true. h5_flush_size is the number of values that is added to a h5 file per write.

Additionally, a new config parameter called software_timeout has been added to the required section of the recording config file. This timeout adds a hard timeout between each digitiser poll in the acquisition worker thread's hot loop. This is useful when testing high sample rate digitisers with many triggers as the buffers on the digitisers can fill very quickly. 

Currently, the code is only functional with the DPP-DSD firmware. DPP-DSD on the digitiser in use only allows for individual channel readout, so triggering on channel 2 and receiving both channel 1 and 2 is not feasible. This will be implemented when moving over to the SCOPE firmware. 