### PR TITLE
Implement `SCOPE` digitiser firmware

### DIFF
--- a/CAENBoard_GENERICLog.txt
+++ b/CAENBoard_GENERICLog.txt
@@ -1,2 +1,0 @@
-[       0.009][EE][CAENBoard_GENERIC.c::2526]: Open digitizer failed due to a comm error: -1
-[       0.009][EE][CAENDPPLayer.c::118]: From c_newDigitizer: Error Calling CAENDigitizer API

--- a/configs/digitiser/wd1_scope_V1730_A4818.conf
+++ b/configs/digitiser/wd1_scope_V1730_A4818.conf
@@ -1,0 +1,9 @@
+[required]
+
+dig_name         = 'V1730_A4818'
+dig_gen          = 1
+con_type         = 'usb_A4818'
+link_num         = 42898
+conet_node       = 0
+vme_base_address = 0
+dig_authority    = 'caen.internal'

--- a/configs/recording/scope_a4818_V1730_SELFTRIG.conf
+++ b/configs/recording/scope_a4818_V1730_SELFTRIG.conf
@@ -1,0 +1,57 @@
+# SELFTRIG example, where ch1 has a large signal, and both other channels are noise 
+# So we trigger on ch1, and not the others. All channels are collected per each trigger (unlike DPP-PSD firmware)
+[required]
+
+record_length  = 4096  # ns
+pre_trigger    = 512   # ns
+trigger_mode   = 'SELFTRIG' # look into the differing methods, trigger on channel based on threshold is an option
+                          # SWTRIG, SELFTRIG, (not yet implemented) <EXTTRIG>
+software_timeout = 0      # hard software timeout between each digitiser poll (s)
+
+[channel_settings]
+
+ch0 =   {'enabled'     : False,
+         'self_trigger': True,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}     # ADCs, only applies of self_trigger enabled
+
+ch1 =   {'enabled'     : True,
+         'self_trigger': True,
+         'threshold'   : 1600,
+         'polarity'    : 'positive'}
+         
+ch2 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch3 =   {'enabled'     : True,
+         'self_trigger': False,
+         'threshold'   : 1,
+         'polarity'    : 'positive'}
+
+ch4 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch5 =   {'enabled'     : True,
+         'self_trigger': False,
+         'threshold'   : 1,
+         'polarity'    : 'positive'}
+
+ch6 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch7 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+[output_settings]
+
+file_name = '../CARP_FILES/SCOPE_testing/a4818test'    # this will always be appended with a timestamp and .h5
+overwrite = True                  # overwrite the file if you want
+h5_flush_size = 10000                # number of values added to h5 files per write

--- a/configs/recording/scope_a4818_V1730_SWTRIG.conf
+++ b/configs/recording/scope_a4818_V1730_SWTRIG.conf
@@ -1,0 +1,58 @@
+# Software trigger example, where channel 1, 3 and 5 are outputting data.
+# self_trigger is irrelevant here, as long as the channel is enabled, it will work
+
+[required]
+
+record_length  = 4096  # ns
+pre_trigger    = 512   # ns
+trigger_mode   = 'SWTRIG' # look into the differing methods, trigger on channel based on threshold is an option
+                          # SWTRIG, SELFTRIG, (not yet implemented) <EXTTRIG>
+software_timeout = 0      # hard software timeout between each digitiser poll (s)
+
+[channel_settings]
+
+ch0 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}     # ADCs, only applies of self_trigger enabled
+
+ch1 =   {'enabled'     : True,
+         'self_trigger': True,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+         
+ch2 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 600,
+         'polarity'    : 'positive'}
+
+ch3 =   {'enabled'     : True,
+         'self_trigger': True,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch4 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch5 =   {'enabled'     : True,
+         'self_trigger': True,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch6 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+ch7 =   {'enabled'     : False,
+         'self_trigger': False,
+         'threshold'   : 0,
+         'polarity'    : 'positive'}
+
+[output_settings]
+
+file_name = '../CARP_FILES/SCOPE_testing/a4818test'    # this will always be appended with a timestamp and .h5
+overwrite = True                  # overwrite the file if you want
+h5_flush_size = 10000                # number of values added to h5 files per write

--- a/core/controller.py
+++ b/core/controller.py
@@ -28,6 +28,7 @@ from core.commands import CommandType, Command
 from core.worker import AcquisitionWorker
 from core.writer import Writer
 from core.tracker import Tracker
+from core.functions import get_ch_mapping
 from felib.digitiser import Digitiser
 from ui import oscilloscope
 
@@ -80,7 +81,7 @@ class Controller:
         logging.info("Acquisition worker thread started.")
 
         # Multi channel writes to h5
-        self.ch_mapping = self.get_ch_mapping()
+        self.ch_mapping = get_ch_mapping(self.rec_dict)
         self.num_ch = len(self.ch_mapping)
         self.h5_flush_size = self.rec_dict['h5_flush_size']
         self.writer_buffers = [Queue(maxsize=1024) for _ in range(self.num_ch)]
@@ -105,24 +106,6 @@ class Controller:
 
         self.connect_digitiser()
 
-    def get_ch_mapping(self):
-        '''
-        Extract what channels are being used map them: ch -> index
-
-        So shape will be:
-        mapping = {0 : 0, 3 : 1, 5 : 2}
-        for the case where ch0, 3, and 5 are enabled
-        '''
-        mapping = {}
-        i = 0
-        for entry in self.rec_dict:
-            if 'ch' in entry:
-                if self.rec_dict[entry]['enabled']:
-                    ch = int(entry[2:])
-                    mapping[ch] = i
-                    i += 1
-
-        return mapping
 
     def data_handling(self):
         '''

--- a/core/controller.py
+++ b/core/controller.py
@@ -120,7 +120,7 @@ class Controller:
 
             try:
                 # you must pass wf_size and ADCs through.
-                wf_size, ADCs, ch = data
+                wf_size, ADCs, ch, timestamp = data
 
                 # update visuals
                 self.main_window.screen.update_ch(np.arange(0, wf_size, dtype=wf_size.dtype), ADCs, ch)
@@ -130,7 +130,7 @@ class Controller:
 
                 # push data to writer buffer
                 if self.recording:
-                    write_data = wf_size, ADCs, self.event_counter
+                    write_data = wf_size, ADCs, self.event_counter, timestamp
 
                     # multi channel writing
                     ch = int(ch)

--- a/core/controller.py
+++ b/core/controller.py
@@ -83,6 +83,7 @@ class Controller:
         # Multi channel writes to h5
         self.ch_mapping = get_ch_mapping(self.rec_dict)
         self.num_ch = len(self.ch_mapping)
+        self.max_ch = max(self.ch_mapping.keys())
         self.h5_flush_size = self.rec_dict['h5_flush_size']
         self.writer_buffer = Queue(maxsize=1024)
         self.writer = Writer(
@@ -132,7 +133,9 @@ class Controller:
                     write_data = wf_size, ch, ADCs, self.event_counter, timestamp
                     self.writer_buffer.put(write_data)
 
-                self.event_counter += 1
+                # stupid catch to ensure event number only increases with channel
+                if ch == self.max_ch:
+                    self.event_counter += 1
 
             except Exception as e:
                 logging.exception(f"Error updating display: {e}")

--- a/core/functions.py
+++ b/core/functions.py
@@ -1,0 +1,21 @@
+
+def get_ch_mapping(rec_dict):
+    '''
+    Extract what channels are being used map them: ch -> index
+
+    So shape will be:
+    mapping = {0 : 0, 3 : 1, 5 : 2}
+    for the case where ch0, 3, and 5 are enabled
+    '''
+    mapping = {}
+    i = 0
+    for entry in rec_dict:
+        if 'ch' in entry:
+            if rec_dict[entry]['enabled']:
+                ch = int(entry[2:])
+                mapping[ch] = i
+                i += 1
+
+    return mapping
+
+

--- a/core/worker.py
+++ b/core/worker.py
@@ -125,20 +125,20 @@ class AcquisitionWorker(Thread):
                             continue
                         # extract each channel separately and push to buffers
                         for channel_data in data:
-                        # Non-blocking put to visual buffer
-                        if self.display_buffer.full():
-                            try:
-                                self.display_buffer.get_nowait()  # discard oldest
-                            except Empty:
-                                pass
+                            # Non-blocking put to visual buffer
+                            if self.display_buffer.full():
+                                try:
+                                    self.display_buffer.get_nowait()  # discard oldest
+                                except Empty:
+                                    pass
 
-                        # Push to display buffer (etc.)
-                        if not self.display_buffer.full():
-                            self.display_buffer.put_nowait(channel_data)
+                            # Push to display buffer (etc.)
+                            if not self.display_buffer.full():
+                                self.display_buffer.put_nowait(channel_data)
 
-                        # Notify controller/UI
-                        if self.data_ready_callback:
-                            self.data_ready_callback()
+                            # Notify controller/UI
+                            if self.data_ready_callback:
+                                self.data_ready_callback()
 
                     except Exception as e:
                         logging.exception(f"Acquisition error: {e}")

--- a/core/worker.py
+++ b/core/worker.py
@@ -74,7 +74,7 @@ class AcquisitionWorker(Thread):
             logging.info("Digitiser acquisition started successfully.")
         except Exception as e:
             logging.exception(f"Start acquisition failed: {e}")
-    
+
     def connect_digitiser(self, dig_config, rec_config):
         '''
         Connect to digitiser with given configs.
@@ -123,7 +123,8 @@ class AcquisitionWorker(Thread):
                         data = self.digitiser.acquire()
                         if data is None:
                             continue
-
+                        # extract each channel separately and push to buffers
+                        for channel_data in data:
                         # Non-blocking put to visual buffer
                         if self.display_buffer.full():
                             try:
@@ -133,7 +134,7 @@ class AcquisitionWorker(Thread):
 
                         # Push to display buffer (etc.)
                         if not self.display_buffer.full():
-                            self.display_buffer.put_nowait(data)
+                            self.display_buffer.put_nowait(channel_data)
 
                         # Notify controller/UI
                         if self.data_ready_callback:
@@ -154,7 +155,7 @@ class AcquisitionWorker(Thread):
 
     def cleanup(self):
         '''
-        Cleans up digitiser by calling stop_acquisition and its destructor. 
+        Cleans up digitiser by calling stop_acquisition and its destructor.
         '''
         if self.digitiser:
             if self.digitiser.isAcquiring:

--- a/core/writer.py
+++ b/core/writer.py
@@ -83,7 +83,8 @@ class Writer(Thread):
         self.local_buffer.clear()
 
         # flush as fast as the buffer provides
-        self.rwf_table[ch].flush()
+        for ch_local in self.ch_map.keys():
+            self.rwf_table[ch_local].flush()
         pass
 
 

--- a/core/writer.py
+++ b/core/writer.py
@@ -12,7 +12,7 @@ class Writer(Thread):
     Writes channel data to h5 file.
     '''
     def __init__(self,
-                 ch           : int,
+                 ch_map       : dict,
                  flush_size   : int,
                  write_buffer : Queue,
                  stop_event   : Event,
@@ -25,21 +25,19 @@ class Writer(Thread):
         '''
 
         super().__init__(daemon=True)
-        self.ch = ch
         self.flush_size = flush_size
         self.write_buffer = write_buffer
         self.stop_event = stop_event
         self.rec_config = rec_config
         self.dig_config = dig_config
-        self.filename = f"some_name_ch_{self.ch}"
         self.local_buffer = []
         self.wf_size   = None
 
         if 'file_name' in self.rec_config:
             file_path = self.rec_config['file_name']
-            file_path = f'{file_path}_{self.ch}_{TIMESTAMP}.h5'
+            file_path = f'{file_path}_data_{TIMESTAMP}.h5'
         else:
-            file_path = f'{self.ch}_{TIMESTAMP}.h5'
+            file_path = f'data_{TIMESTAMP}.h5'
         # initialise the h5, one per channel, each handled on a separate thread
         try:
             self.h5file = tb.open_file(f'{file_path}', mode='a')
@@ -50,8 +48,10 @@ class Writer(Thread):
         io.create_config_table(self.h5file, self.rec_config, 'rec_conf', 'recording config')
         io.create_config_table(self.h5file, self.dig_config, 'dig_conf', 'digitiser config')
         # raw waveform group constructed
-        self.rwf_group = self.h5file.create_group('/', f'ch_{ch}', 'raw waveform')
-
+        self.rwf_group = {}
+        for ch in ch_map.keys():
+            self.rwf_group[ch] = self.h5file.create_group('/', f'ch_{ch}', 'raw waveform')
+        self.rwf_table = {}
 
     def write_h5(self):
         '''
@@ -62,24 +62,24 @@ class Writer(Thread):
         where ADCs is the actual raw waveform array
         '''
 
-        for wf_size, rwf, evt, ts in self.local_buffer:
+        for wf_size, ch, rwf, evt, ts in self.local_buffer:
         # if we know the size of the waveforms already, don't create the class again.
             if self.wf_size is None:
                 self.wf_size = wf_size
                 self.rwf_class = df_class.return_rwf_class(self.dig_config['dig_gen'], self.wf_size)
-                self.rwf_table = self.h5file.create_table(self.rwf_group, 'rwf', self.rwf_class, "raw waveforms")
-                self.rows      =  self.rwf_table.row
+                self.rwf_table[ch] = self.h5file.create_table(self.rwf_group[ch], 'rwf', self.rwf_class, "raw waveforms")
+                self.rows      =  self.rwf_table[ch].row
 
             self.rows['evt_no']    = evt
             self.rows['rwf']       = rwf
-            self.rows['channel']   = self.ch
+            self.rows['channel']   = ch
             self.rows['timestamp'] = ts
             self.rows.append()
 
         self.local_buffer.clear()
 
         # flush as fast as the buffer provides
-        self.rwf_table.flush()
+        self.rwf_table[ch].flush()
         pass
 
 
@@ -87,7 +87,7 @@ class Writer(Thread):
         '''
         Writer hot loop.
         '''
-        logging.info(f"Writer thread started (ch {self.ch}).")
+        logging.info(f"Writer thread started.")
         try:
             while not self.stop_event.is_set():
                 # First load data from shared buffer into local buffer
@@ -105,11 +105,11 @@ class Writer(Thread):
                 self.write_h5()
 
         except Exception as e:
-            logging.exception(f"Fatal error in Writer (ch {self.ch}): {e}")
+            logging.exception(f"Fatal error in Writer: {e}")
 
         # When stop_event() is set, call cleanup()
         self.cleanup()
-        logging.info(f"Writer thread exited cleanly (ch {self.ch}).")
+        logging.info(f"Writer thread exited cleanly.")
 
     def cleanup(self):
         '''

--- a/core/writer.py
+++ b/core/writer.py
@@ -72,6 +72,7 @@ class Writer(Thread):
 
             self.rows['evt_no']    = evt
             self.rows['rwf']       = rwf
+            self.rows['channel']   = self.ch
             self.rows['timestamp'] = ts
             self.rows.append()
 

--- a/core/writer.py
+++ b/core/writer.py
@@ -62,7 +62,7 @@ class Writer(Thread):
         where ADCs is the actual raw waveform array
         '''
 
-        for wf_size, rwf, evt in self.local_buffer:
+        for wf_size, rwf, evt, ts in self.local_buffer:
         # if we know the size of the waveforms already, don't create the class again.
             if self.wf_size is None:
                 self.wf_size = wf_size
@@ -70,8 +70,9 @@ class Writer(Thread):
                 self.rwf_table = self.h5file.create_table(self.rwf_group, 'rwf', self.rwf_class, "raw waveforms")
                 self.rows      =  self.rwf_table.row
 
-            self.rows['evt_no'] = evt
-            self.rows['rwf']    = rwf
+            self.rows['evt_no']    = evt
+            self.rows['rwf']       = rwf
+            self.rows['timestamp'] = ts
             self.rows.append()
 
         self.local_buffer.clear()

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -155,8 +155,10 @@ class Digitiser():
 
                 # normal channel management
                 ch.par.CH_ENABLED.value = 'TRUE' if ch_dict['enabled'] else 'FALSE'
-                if   self.dig.par.FWTYPE.value == 'DPP-PSD' : ch.par.CH_PRETRIG.value = f{'self.pre_trigger'}
-                elif self.dig.par.FWTYPE.value == 'SCOPE'   : ch.par.POSTTRG.value    = f'{self.record_length - self.pre_trigger}'
+                # for SCOPE, this doesnt need to be set per channel, but i prefer these to be set together
+                # even if its a bit redundant
+                if   self.dig.par.FWTYPE.value == 'DPP-PSD' : ch.par.CH_PRETRIG.value = f'{self.pre_trigger}'
+                elif self.dig.par.FWTYPE.value == 'SCOPE'   : self.dig.par.POSTTRG.value    = f'{self.record_length - self.pre_trigger}'
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
                 if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':
@@ -296,7 +298,7 @@ class Digitiser():
                 for ch in ch_mapping.keys():
                     output.append((self.waveform_size[ch], self.waveform[ch], ch, self.timestamp))
             # DPP-PSD triggers per channel, so needs to be treated as such
-            elif self.dig.par.FWTYPE.value == 'DPP-PSD'
+            elif self.dig.par.FWTYPE.value == 'DPP-PSD':
                 output = [(self.waveform_size, self.waveform, self.channel, self.timestamp)]
 
             return output
@@ -335,7 +337,7 @@ class Digitiser():
                 for ch in ch_mapping.keys():
                     output.append((self.waveform_size[ch], self.waveform[ch], ch, self.timestamp))
             # DPP-PSD triggers per channel, so needs to be treated as such
-            elif self.dig.par.FWTYPE.value == 'DPP-PSD'
+            elif self.dig.par.FWTYPE.value == 'DPP-PSD':
                 output = [(self.waveform_size, self.waveform, self.channel, self.timestamp)]
 
             return output

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -42,12 +42,12 @@ class Digitiser():
         else:
             logging.error("Invalid digitiser generation specified in the configuration.")
             #raise ValueError("Invalid digitiser generation specified in the configuration.")
-        
+
         self.URI = self.generate_uri()
         self.isAcquiring = False
         self.isConnected = False
         self.isRecording = False
-        
+
         self.data_format = []
         self.endpoint = None
 
@@ -74,15 +74,15 @@ class Digitiser():
         else:
             logging.error("Invalid digitiser generation specified in the configuration.")
             #raise ValueError("Invalid digitiser generation specified in the configuration.")
-        
+
 
     def connect(self):
         '''
         Connect to the digitiser using the generated URI.
         '''
-        
+
         logging.info(f'Attemping connection to digitiser {self.dig_name} at {self.URI}.')
-        
+
         # fake connection for debugging
         if self.dig_name == 'debug':
             self.dig = None
@@ -114,7 +114,7 @@ class Digitiser():
             return None
 
 
-    def configure(self, 
+    def configure(self,
                   dig_dict : dict,
                   rec_dict : dict):
                   #record_length: Optional[int] = 0,
@@ -122,7 +122,7 @@ class Digitiser():
                   #trigger_level: Optional[str] = 'SWTRG'):
         '''
         Configure the digitiser with the provided settings and calibrate it.
-        '''        
+        '''
 
         self.record_length = rec_dict.get('record_length')
         self.pre_trigger   = rec_dict.get('pre_trigger')
@@ -143,10 +143,12 @@ class Digitiser():
 
                 # extract channel config of interest
                 ch_dict = rec_dict.get(f'ch{i}')
-                
+
+                # disable channel if not explicitly called
                 if ch_dict is None:
+                    ch.par.CH_ENABLED.value = 'FALSE'
                     continue
-                
+
                 ch.par.CH_ENABLED.value      = 'TRUE' if ch_dict['enabled'] else 'FALSE'
                 ch.par.CH_PRETRG.value = f'{self.pre_trigger}'
 
@@ -157,7 +159,7 @@ class Digitiser():
                 else:
                     # doesn't reset by default! so forcing this here
                     ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
-                
+
                 if ch_dict['polarity'] == 'positive':
                     ch.par.CH_POLARITY.value        = 'POLARITY_POSITIVE'
                 elif ch_dict['polarity'] == 'negative':
@@ -166,7 +168,7 @@ class Digitiser():
                 else:
                     ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
                 # technically customisable
-                
+
 
 
             # calculate the true reclen value for outputting
@@ -179,12 +181,12 @@ class Digitiser():
                 self.data_format = formats.DPP(int(self.dig.par.NUMCH.value), int(self.reclen))
                 # setting up probe types (READ UP ON THIS)
                 self.dig.vtrace[0].par.VTRACE_PROBE.value = 'VPROBE_INPUT'
-            
+
             endpoint_path = (self.dig.par.FWTYPE.value).replace('-', '')
             self.endpoint = self.dig.endpoint[endpoint_path]
             self.data = self.endpoint.set_read_data_format(self.data_format)
 
-        
+
             logging.info(f"Digitiser configured:\nrecord length {self.record_length}, pre-trigger {self.pre_trigger}, trigger mode {self.trigger_mode}.")
         except Exception as e:
             logging.exception(f"Failed to configure recording parameters.\n{e}")
@@ -207,18 +209,18 @@ class Digitiser():
             self.dig.cmd.ARMACQUISITION()
         except Exception as e:
             logging.exception(f"Starting acquisition failed: {e}")
-        
+
         # start recording function
         #self.trigger_and_record()
         #try:
             #self.dig.cmd.START()
-            #self.collect = True    
+            #self.collect = True
             #print("Digitiser acquisition started.")
         #except Exception as e:
         #    raise RuntimeError(f"Failed to start digitiser acquisition.\n{e}")
              #self.collect = True
-        
-    
+
+
     def stop_acquisition(self):
         '''
         Stop the digitiser acquisition.
@@ -242,7 +244,7 @@ class Digitiser():
                 return self.SELFTRIG_record()
             case _:
                 logging.info(f'Trigger mode {self.trigger_mode} not currently implemented.')
-                self.stop_acquisition()    
+                self.stop_acquisition()
 
 
     def SW_record(self):
@@ -266,16 +268,16 @@ class Digitiser():
             if ex.code is error.ErrorCode.STOP:
                 logging.exception("STOP")
                 raise ex
-        
+
         # ensure the input and trigger are acceptable (I think?)
         #assert self.data[3].value == 1 # VPROBE INPUT? I need to understand this
         #assert self.data[6].value == 1 # VPROBE TRIGGER?
-        
+
         #waveform_size = self.data[7].value
         #valid_sample_range = np.arange(0, waveform_size, dtype = waveform_size.dtype)
 
-        
-    
+
+
     def SELFTRIG_record(self):
         '''
         Trigger on channels

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -162,22 +162,21 @@ class Digitiser():
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
                 # recall that this functions like so for DPP-PSD, with SCOPE, if a channel is enabled the self-trigger is also enabled
-                if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':
+                if (ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG'):
                     if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
+                    if self.dig.par.FWTYPE.value    == 'SCOPE'   : ch.par.CH_TRG_GLOBAL_GEN.value  = 'TRUE'
 
                     ch.par.CH_THRESHOLD.value       = str(ch_dict['threshold'])
                 else:
                     # doesn't reset by default! so forcing this here
                     if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
+                    if self.dig.par.FWTYPE.value    == 'SCOPE'   : ch.par.CH_TRG_GLOBAL_GEN.value  = 'FALSE'
 
                 if ch_dict['polarity'] == 'positive':
                     ch.par.CH_POLARITY.value        = 'POLARITY_POSITIVE'
                 elif ch_dict['polarity'] == 'negative':
                     ch.par.CH_POLARITY.value        = 'POLARITY_NEGATIVE'
 
-                else:
-                    if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
-                # technically customisable
 
 
 

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 import time
 
+from core.functions import get_ch_mapping
 from felib.dig1_utils import generate_digitiser_uri
 
 import felib.formats as formats
@@ -127,6 +128,9 @@ class Digitiser():
         self.record_length = rec_dict.get('record_length')
         self.pre_trigger   = rec_dict.get('pre_trigger')
         self.trigger_mode  = rec_dict.get('trigger_mode')
+
+        # extract channel mapping
+        self.ch_mapping    = get_ch_mapping(rec_dict)
 
         try:
 

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -151,18 +151,18 @@ class Digitiser():
 
                 # normal channel management
                 ch.par.CH_ENABLED.value = 'TRUE' if ch_dict['enabled'] else 'FALSE'
-                if   self.dig.par.FWTYPE.value == 'DPP-DSD' : ch.par.CH_PRETRIG.value = f{'self.pre_trigger'}
+                if   self.dig.par.FWTYPE.value == 'DPP-PSD' : ch.par.CH_PRETRIG.value = f{'self.pre_trigger'}
                 elif self.dig.par.FWTYPE.value == 'SCOPE'   : ch.par.POSTTRG.value    = f'{self.record_length - self.pre_trigger}'
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
                 if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':
-                    if self.dig.par.FWTYPE.value    == 'DPP-DSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
+                    if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
 
                     ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
                     ch.par.CH_THRESHOLD.value       = str(ch_dict['threshold'])
                 else:
                     # doesn't reset by default! so forcing this here
-                    if self.dig.par.FWTYPE.value    == 'DPP-DSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
+                    if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
 
                 if ch_dict['polarity'] == 'positive':
                     ch.par.CH_POLARITY.value        = 'POLARITY_POSITIVE'

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -161,10 +161,10 @@ class Digitiser():
                 elif self.dig.par.FWTYPE.value == 'SCOPE'   : self.dig.par.POSTTRG.value    = f'{self.record_length - self.pre_trigger}'
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
+                # recall that this functions like so for DPP-PSD, with SCOPE, if a channel is enabled the self-trigger is also enabled
                 if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':
                     if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
 
-                    ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
                     ch.par.CH_THRESHOLD.value       = str(ch_dict['threshold'])
                 else:
                     # doesn't reset by default! so forcing this here
@@ -176,7 +176,7 @@ class Digitiser():
                     ch.par.CH_POLARITY.value        = 'POLARITY_NEGATIVE'
 
                 else:
-                    ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
+                    if self.dig.par.FWTYPE.value    == 'DPP-PSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
                 # technically customisable
 
 
@@ -295,7 +295,7 @@ class Digitiser():
             if self.dig.par.FWTYPE.value == 'SCOPE':
                 output = []
                 # using the mapping extract the relevant channels
-                for ch in ch_mapping.keys():
+                for ch in self.ch_mapping.keys():
                     output.append((self.waveform_size[ch], self.waveform[ch], ch, self.timestamp))
             # DPP-PSD triggers per channel, so needs to be treated as such
             elif self.dig.par.FWTYPE.value == 'DPP-PSD':
@@ -334,7 +334,7 @@ class Digitiser():
             if self.dig.par.FWTYPE.value == 'SCOPE':
                 output = []
                 # using the mapping extract the relevant channels
-                for ch in ch_mapping.keys():
+                for ch in self.ch_mapping.keys():
                     output.append((self.waveform_size[ch], self.waveform[ch], ch, self.timestamp))
             # DPP-PSD triggers per channel, so needs to be treated as such
             elif self.dig.par.FWTYPE.value == 'DPP-PSD':

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -179,12 +179,18 @@ class Digitiser():
             reclen_ns = int(self.dig.par.RECLEN.value)
             self.reclen    = int(reclen_ns / int(1e3 / self.dig_info['sample_rate']))
 
-            # if DPP, need to specify that you're looking at waveforms specifically.
-            if self.dig.par.FWTYPE.value == 'DPP-PSD':
-                self.dig.par.WAVEFORMS.value = 'TRUE'
-                self.data_format = formats.DPP(int(self.dig.par.NUMCH.value), int(self.reclen))
-                # setting up probe types (READ UP ON THIS)
-                self.dig.vtrace[0].par.VTRACE_PROBE.value = 'VPROBE_INPUT'
+            # set up data format
+            match self.dig.par.FWTYPE.value:
+                case 'DPP-PSD':
+                    # enforce waveform formatting
+                    self.dig.par.WAVEFORMS.value = 'TRUE'
+                    self.data_format = formats.DPP(  int(self.dig.par.NUMCH.value), int(self.reclen))
+                    # setting up probe types (READ UP ON THIS)
+                    self.dig.vtrace[0].par.VTRACE_PROBE.value = 'VPROBE_INPUT'
+                case 'SCOPE':
+                    self.data_format = formats.SCOPE(int(self.dig.par.NUMCH.value), int(self.reclen))
+                case _:
+                    logging.exception(f"Firmware type {self.dig.par.FWTYPE.value} not recognised.\nCurrent FWs available are DPP-DSD and SCOPE")
 
             endpoint_path = (self.dig.par.FWTYPE.value).replace('-', '')
             self.endpoint = self.dig.endpoint[endpoint_path]

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -149,8 +149,10 @@ class Digitiser():
                     ch.par.CH_ENABLED.value = 'FALSE'
                     continue
 
-                ch.par.CH_ENABLED.value      = 'TRUE' if ch_dict['enabled'] else 'FALSE'
-                ch.par.CH_PRETRG.value = f'{self.pre_trigger}'
+                # normal channel management
+                ch.par.CH_ENABLED.value = 'TRUE' if ch_dict['enabled'] else 'FALSE'
+                if   self.dig.par.FWTYPE.value == 'DPP-DSD' : ch.par.CH_PRETRIG.value = f{'self.pre_trigger'}
+                elif self.dig.par.FWTYPE.value == 'SCOPE'   : ch.par.POSTTRG.value    = f'{self.record_length - self.pre_trigger}'
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
                 if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':

--- a/felib/digitiser.py
+++ b/felib/digitiser.py
@@ -156,11 +156,13 @@ class Digitiser():
 
                 # ensure self trigger only enabled when you don't have SWTRIG enabled
                 if ch_dict['self_trigger'] and self.trigger_mode != 'SWTRIG':
+                    if self.dig.par.FWTYPE.value    == 'DPP-DSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
+
                     ch.par.CH_SELF_TRG_ENABLE.value = 'TRUE'
                     ch.par.CH_THRESHOLD.value       = str(ch_dict['threshold'])
                 else:
                     # doesn't reset by default! so forcing this here
-                    ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
+                    if self.dig.par.FWTYPE.value    == 'DPP-DSD' : ch.par.CH_SELF_TRG_ENABLE.value = 'FALSE'
 
                 if ch_dict['polarity'] == 'positive':
                     ch.par.CH_POLARITY.value        = 'POLARITY_POSITIVE'

--- a/felib/formats.py
+++ b/felib/formats.py
@@ -5,7 +5,7 @@ def DPP(nch, record_length):
     DPP-DSD format
     nch - number of channels
     '''
-    
+
     # Configure endpoint
     data_format = [
         {
@@ -49,6 +49,39 @@ def DPP(nch, record_length):
             'name': 'WAVEFORM_SIZE',
             'type': 'SIZE_T',
             'dim': 0,
+        }
+    ]
+
+    return data_format
+
+
+def SCOPE(nch, record_length):
+    '''
+    SCOPE format
+    nch - number of channels
+    '''
+
+    # Configure endpoint
+    data_format = [
+        {
+            'name': 'EVENT_SIZE',
+            'type': 'SIZE_T',
+        },
+        {
+            'name': 'TIMESTAMP',
+            'type': 'U64',
+        },
+        {
+            'name': 'WAVEFORM',
+            'type': 'U16',
+            'dim': 2,
+            'shape': [nch, record_length],
+        },
+        {
+            'name': 'WAVEFORM_SIZE',
+            'type': 'SIZE_T',
+            'dim': 1,
+            'shape': [nch],
         }
     ]
 

--- a/ui/oscilloscope.py
+++ b/ui/oscilloscope.py
@@ -53,8 +53,8 @@ class ControlPanel(QFrame):
 
 
 class OscilloScopeScreen(pg.PlotWidget):
-    def __init__(self, parent = None, plotItem = None, **kwargs):
-        super().__init__(parent=parent, background='w', plotItem=plotItem, **kwargs)
+    def __init__(self, controller, parent = None, plotItem = None, **kwargs):
+        super().__init__(parent=parent, controller=controller, background='w', plotItem=plotItem, **kwargs)
 
         styles = {'color': 'k', 'font-size': '12px'}
         self.setLabel('left', 'Voltage (ADCs)', **styles)
@@ -64,18 +64,19 @@ class OscilloScopeScreen(pg.PlotWidget):
         self.setXRange(0, 1, padding = 0.02)
         self.setYRange(0, 5, padding = 0.02)
 
+        self.legend = self.addLegend()
 
         self.pen_ch   = {}
         self.channels = {}
         # create pens for each channel, and plot the defaults
-        for ch in self.ch_mapping.keys():
+        for ch in controller.ch_mapping.keys():
             self.pen_ch[ch] = pg.mkPen(pg.intColor(ch), width = 1)
             self.plot_ch([0,1], [0,0], ch)
 
-        self.legend = self.addLegend()
+
 
     def plot_ch(self, x, y, ch = 1):
-        self.channels[ch] = self.plot(x, y, pen=self.pen_ch[ch], name = str(ch))
+        self.channels[ch] = self.plot(x, y, pen=self.pen_ch[ch], name = f'ch {ch}')
 
     def update_ch(self, x, y, ch = 1):
         self.channels[ch].setData(x, y)
@@ -93,7 +94,7 @@ class MainWindow(QMainWindow):
     def setupUI(self):
         self.setWindowTitle("CAEN Acqusition and Readout Program (CARP)")
 
-        self.screen        = OscilloScopeScreen()
+        self.screen        = OscilloScopeScreen(self.controller)
         self.control_panel = ControlPanel(self.controller)
 
         self.content_layout = QHBoxLayout()

--- a/ui/oscilloscope.py
+++ b/ui/oscilloscope.py
@@ -55,7 +55,7 @@ class ControlPanel(QFrame):
 class OscilloScopeScreen(pg.PlotWidget):
     def __init__(self, parent = None, plotItem = None, **kwargs):
         super().__init__(parent=parent, background='w', plotItem=plotItem, **kwargs)
-        
+
         styles = {'color': 'k', 'font-size': '12px'}
         self.setLabel('left', 'Voltage (ADCs)', **styles)
         self.setLabel('bottom', 'Time (ns)', **styles)
@@ -64,15 +64,21 @@ class OscilloScopeScreen(pg.PlotWidget):
         self.setXRange(0, 1, padding = 0.02)
         self.setYRange(0, 5, padding = 0.02)
 
-        self.pen_ch1 = pg.mkPen(color = "b", width = 1)
 
-        self.plot_ch([0,1], [0,0])
-    
+        self.pen_ch   = {}
+        self.channels = {}
+        # create pens for each channel, and plot the defaults
+        for ch in self.ch_mapping.keys():
+            self.pen_ch[ch] = pg.mkPen(pg.intColor(ch), width = 1)
+            self.plot_ch([0,1], [0,0], ch)
+
+        self.legend = self.addLegend()
+
     def plot_ch(self, x, y, ch = 1):
-        self.data_line_ch = self.plot(x, y, pen=self.pen_ch1)
+        self.channels[ch] = self.plot(x, y, pen=self.pen_ch[ch], name = str(ch))
 
     def update_ch(self, x, y, ch = 1):
-        self.data_line_ch.setData(x, y)
+        self.channels[ch].setData(x, y)
 
 
 class MainWindow(QMainWindow):
@@ -81,12 +87,12 @@ class MainWindow(QMainWindow):
 
         # Define interactivity through controller
         self.controller = controller
-        
+
         self.setupUI()
-    
+
     def setupUI(self):
         self.setWindowTitle("CAEN Acqusition and Readout Program (CARP)")
-        
+
         self.screen        = OscilloScopeScreen()
         self.control_panel = ControlPanel(self.controller)
 


### PR DESCRIPTION
This PR introduces the `SCOPE` digitiser firmware into CARP, allowing for any compatible Dig 1* SCOPE digitisers to be used with CARP.

This includes self-triggering, and software triggering. Three new configs have been added with small explanations of how each functions.

Other small changes were made to the structure of the read out file (due to unforeseen issues with HDF5 not being multithreaded). We may implement faster readout in the future, but I don't believe this to be our current bottleneck.

In making this PR, the speed of CARP has been noted to be relatively slow (maxing out at ~50Hz with N channels. It's not channel dependent) This may be in part due to python's GIL, but I believe we're losing speed elsewhere in the system. The GUI needs to be adjusted for high frequency data taking (#30) and the rest of the code needs to be assessed for performance (#31).

*_Dig 1 is the only type I've tested to far, specifically with the V1730B digitiser_ 

Here's a visualisation of the SCOPE digitiser working.
[Screencast from 17-01-26 14_08_32.webm](https://github.com/user-attachments/assets/3bc8e6f7-6463-4eca-a89b-f506d83eb330)
And an example resultant output:
<img width="1129" height="827" alt="image" src="https://github.com/user-attachments/assets/dec858e1-bb8f-4542-80d6-e20a26e0be0a" />

